### PR TITLE
make arrows and skip behavior configurable

### DIFF
--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -174,11 +174,10 @@ function letter(keycode) {
     dc = 1;
   sq = find_blank_in_word(square, dr, dc);
   first = first_blank(selected_clue());
-  if (sq)
+  if (sq && Meteor.user().profile.settingWithinWord == "skip")
     select(sq);
-  else if (sq === null && first) {
-    select(first);
-  }
+  else if (sq === null && first && Meteor.user().profile.settingEndWordBack)
+      select(first);
   else if (Session.get('selected-direction') == 'across')
     move(0, 1, true);
   else
@@ -256,11 +255,15 @@ function handle_key(k) {
   }
   if (k.altKey || k.ctrlKey || k.metaKey)
     return true;
-  if ((k.keyCode === 39 || k.keyCode === 37) && Session.get('selected-direction') === 'down') {
+  if ((k.keyCode === 39 || k.keyCode === 37) &&
+      Session.get('selected-direction') === 'down' &&
+      Meteor.user().profile.settingArrows === "stay") { 
     Session.set('selected-direction', 'across');
     return false;
   }
-  else if ((k.keyCode === 38 || k.keyCode === 40) && Session.get('selected-direction') === 'across') {
+  else if ((k.keyCode === 38 || k.keyCode === 40) &&
+           Session.get('selected-direction') === 'across' &&
+           Meteor.user().profile.settingArrows === "stay") { 
     Session.set('selected-direction', 'down');
     return false;
   }

--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -230,7 +230,15 @@ function handle_key(k) {
   }
   if (k.altKey || k.ctrlKey || k.metaKey)
     return true;
-  if (k.keyCode === 39)
+  if ((k.keyCode === 39 || k.keyCode === 37) && Session.get('selected-direction') === 'down') {
+    Session.set('selected-direction', 'across');
+    return false;
+  }
+  else if ((k.keyCode === 38 || k.keyCode === 40) && Session.get('selected-direction') === 'across') {
+    Session.set('selected-direction', 'down');
+    return false;
+  }
+  else if (k.keyCode === 39)
     return move(0, 1);
   else if (k.keyCode === 37)
     return move(0, -1);

--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -174,9 +174,9 @@ function letter(keycode) {
     dc = 1;
   sq = find_blank_in_word(square, dr, dc);
   first = first_blank(selected_clue());
-  if (sq && Meteor.user().profile.settingWithinWord == "skip")
+  if (sq && Meteor.user() && Meteor.user().profile.settingWithinWord == "skip")
     select(sq);
-  else if (sq === null && first && Meteor.user().profile.settingEndWordBack)
+  else if (sq === null && first && Meteor.user() && Meteor.user().profile.settingEndWordBack)
       select(first);
   else if (Session.get('selected-direction') == 'across')
     move(0, 1, true);
@@ -257,12 +257,14 @@ function handle_key(k) {
     return true;
   if ((k.keyCode === 39 || k.keyCode === 37) &&
       Session.get('selected-direction') === 'down' &&
+      Meteor.user() &&
       Meteor.user().profile.settingArrows === "stay") { 
     Session.set('selected-direction', 'across');
     return false;
   }
   else if ((k.keyCode === 38 || k.keyCode === 40) &&
            Session.get('selected-direction') === 'across' &&
+           Meteor.user() &&
            Meteor.user().profile.settingArrows === "stay") { 
     Session.set('selected-direction', 'down');
     return false;

--- a/client/puzzle.js
+++ b/client/puzzle.js
@@ -137,12 +137,11 @@ function first_blank(word) {
   h['word_' + word.direction] = word.number;
   first = Squares.findOne(h);
   var dr = 0, dc = 0;
-  Session.get('selected-direction') === 'down' ? dr = 1 : dc = 1;
-  blanks = find_blank_in_word(first, dr, dc);
-  if (blanks)
-    return blanks;
+  if (Session.get('selected-direction') === 'down')
+    dr = 1;
   else
-    return false;
+    dc = 1;
+  return find_blank_in_word(first, dr, dc) || false;
 }
 
 function move(dr, dc, inword) {
@@ -172,12 +171,12 @@ function letter(keycode) {
     dr = 1;
   else
     dc = 1;
-  sq = find_blank_in_word(square, dr, dc);
-  first = first_blank(selected_clue());
+  var sq = find_blank_in_word(square, dr, dc);
+  var first = first_blank(selected_clue());
   if (sq && Meteor.user() && Meteor.user().profile.settingWithinWord == "skip")
     select(sq);
   else if (sq === null && first && Meteor.user() && Meteor.user().profile.settingEndWordBack)
-      select(first);
+    select(first);
   else if (Session.get('selected-direction') == 'across')
     move(0, 1, true);
   else
@@ -207,7 +206,7 @@ function find_blank_in_word(square, dr, dc) {
     if (s.black)
       return null;
     else if ((dc && (square.word_across !== s.word_across)) ||
-      (dr && (square.word_down !== s.word_down)))
+             (dr && (square.word_down !== s.word_down)))
       return false;
     var f = FillsBySquare.find({square: s._id, game: Session.get('gameid')});
     return f && f.letter === null;

--- a/client/sidebar.html
+++ b/client/sidebar.html
@@ -105,8 +105,11 @@
             <h5>At the end of a word:</h5>
             <label><input type="checkbox" name="settingEndWordBack" value="back" checked={{isSettingChecked 'settingEndWordBack' 'back' false}}>
             Jump back to first blank in the word (if any)</label><br>
+            <!--
+            // will add support for this. probably.
             <label><input type="checkbox" name="settingEndWordNext" value="next" checked={{isSettingChecked 'settingEndWordNext' 'next' false}}>
             Jump to the next clue (if not jumping back)</label><br>
+            -->
           </form>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
add settings options for 
* changing direction with the arrow keys does/doesn't progress a square along the new direction
* typing in a word does/doesn't overwrite already filled-in squares
* at the end of a word, do/don't jump to the beginning of the word